### PR TITLE
Add Apache Snapshots repository

### DIFF
--- a/karavan-generator/pom.xml
+++ b/karavan-generator/pom.xml
@@ -86,4 +86,17 @@
             </resource>
         </resources>
     </build>
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Add Apache Snapshots repository to karavan-generator until Camel 3.15.0 is released (#158). Currently generator depends on Camel `3.15.0-SNAPSHOT` which is not available in default repositories.