### PR TITLE
Fix native image

### DIFF
--- a/karavan-app/pom.xml
+++ b/karavan-app/pom.xml
@@ -29,9 +29,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-        <version.camel-quarkus>2.6.0</version.camel-quarkus>
+        <version.camel-quarkus>2.7.0</version.camel-quarkus>
         <version.camel-kamelet>0.7.0</version.camel-kamelet>
         <version.camel-k-client>5.12.0</version.camel-k-client>
     </properties>

--- a/karavan-app/src/main/docker/Dockerfile.multistage
+++ b/karavan-app/src/main/docker/Dockerfile.multistage
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:20.3.3-java11 AS build
+FROM quay.io/quarkus/ubi-quarkus-native-image:21.3.0-java11 AS build-gen
 
 ## rsync required for npm to build frontend
 USER root
@@ -24,21 +24,43 @@ RUN microdnf install rsync
 COPY --chown=quarkus:quarkus karavan-generator/mvnw /code/mvnw
 COPY --chown=quarkus:quarkus karavan-generator/.mvn /code/.mvn
 COPY --chown=quarkus:quarkus karavan-generator/ /code/karavan-generator/
+COPY --chown=quarkus:quarkus karavan-core/ /code/karavan-core/
 COPY --chown=quarkus:quarkus karavan-app/ /code/karavan-app/
 COPY --chown=quarkus:quarkus karavan-designer/ /code/karavan-designer/
+# Required as output for KameletGenerator:
+COPY --chown=quarkus:quarkus karavan-vscode/ /code/karavan-vscode/
 
 USER quarkus
 WORKDIR /code
 
-## Build Karavan
+# Generate Camel definitions
 RUN ./mvnw clean compile exec:java -Dexec.mainClass="org.apache.camel.karavan.generator.KaravanGenerator" -f karavan-generator
+
+## Stage 2 : build karavan-core
+FROM node:16-alpine AS build-node
+# Root user as we will not be running this image anyway
+USER root
+WORKDIR /code/karavan-core
+
+COPY --chown=root karavan-core/tsconfig.json /code/karavan-core/
+COPY --chown=root karavan-core/package.json /code/karavan-core/
+COPY --chown=root karavan-core/package-lock.json /code/karavan-core/
+RUN npm install --ignore-scripts
+
+COPY --chown=root --from=build-gen /code/karavan-core/ /code/karavan-core/
+RUN npm run build
+
+## Stage 3 : build karavan-app
+FROM build-gen as build-app
+COPY --chown=quarkus:quarkus --from=build-node /code/karavan-core/lib/ /code/karavan-core/lib/
+COPY --chown=quarkus:quarkus --from=build-node /code/karavan-core/node_modules/ /code/karavan-core/node_modules/
 RUN ./mvnw clean package -Pnative -f karavan-app
 
-## Stage 2 : create the docker final image
+## Stage 4 : create the docker final image
 FROM quay.io/quarkus/quarkus-distroless-image:1.0
-COPY --chown=nonroot --from=build /code/karavan-app/target/*-runner /deployments/application
-COPY --chown=nonroot --from=build /code/karavan-app/src/main/resources/kamelets/* /deployments/kamelets-buildin/
-COPY --chown=nonroot --from=build /code/karavan-app/src/main/resources/components/* /deployments/components/
+COPY --chown=nonroot --from=build-app /code/karavan-app/target/*-runner /deployments/application
+COPY --chown=nonroot --from=build-app /code/karavan-app/src/main/resources/kamelets/* /deployments/kamelets-buildin/
+COPY --chown=nonroot --from=build-app /code/karavan-app/src/main/resources/components/* /deployments/components/
 
 EXPOSE 8080
 USER nonroot

--- a/karavan-generator/pom.xml
+++ b/karavan-generator/pom.xml
@@ -29,7 +29,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.6.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <version.camel-core>3.15.0-SNAPSHOT</version.camel-core>
         <version.camel-kamelet>0.7.0</version.camel-kamelet>


### PR DESCRIPTION
I noticed Dockerfile.multistage did not compile since the repository was restructured. This PR:
- Updates the Dockerfile to pull in more subprojects
- Adds an additional build stage for karavan-core
- Updates Quarkus to 2.7.0. This appeared to be required for successful compilation. If you object I can dive into the version differences further.
- Depends  #on #171 