### PR TITLE
Fix #278 windows path issue, Fix #228 allow delete of RouteDefinition to delete Integration

### DIFF
--- a/karavan-designer/src/designer/route/DslElement.tsx
+++ b/karavan-designer/src/designer/route/DslElement.tsx
@@ -200,7 +200,7 @@ export class DslElement extends React.Component<Props, State> {
                     <Text className={this.hasWideChildrenElement() ? "text text-right" : "text text-bottom"}>{CamelUi.getElementTitle(this.state.step)}</Text>
                 </div>
                 {showInsertButton && this.getInsertElementButton()}
-                {this.state.step.dslName !== 'FromDefinition' && this.getDeleteButton()}
+                {this.getDeleteButton()}
                 {showAddButton && this.getAddElementButton()}
             </div>
         )

--- a/karavan-vscode/src/utils.ts
+++ b/karavan-vscode/src/utils.ts
@@ -34,7 +34,9 @@ export function save(relativePath: string, yaml: string){
 
 export function getRalativePath(fullPath: string): string {
     const root = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.path : "";
-    const relativePath = path.resolve(fullPath).replace(path.resolve(root) + path.sep, '');
+    const normalizedRoot = vscode.Uri.file(root).fsPath ;
+    const relativePath = path.resolve(fullPath).replace(normalizedRoot + path.sep, '');
+    
     return relativePath;
 }
 


### PR DESCRIPTION
The normalization of the windows path was not being done on the workspace folder path.
not sure what changed in the code reorg.  passing the path through vscode.Uri works.
needs *nix testing.