### PR TITLE
Fix #278 windows path issue

### DIFF
--- a/karavan-vscode/src/utils.ts
+++ b/karavan-vscode/src/utils.ts
@@ -34,7 +34,8 @@ export function save(relativePath: string, yaml: string){
 
 export function getRalativePath(fullPath: string): string {
     const root = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.path : "";
-    const relativePath = path.resolve(fullPath).replace(path.resolve(root) + path.sep, '');
+    const normalizedRoot = vscode.Uri.file(root).fsPath ;
+    const relativePath = path.resolve(fullPath).replace(normalizedRoot + path.sep, '');
     return relativePath;
 }
 


### PR DESCRIPTION
on windows platform, the workspaceFolder format is different than fullPath's format(looks like from vscode.Uri format, which will have lower case drive with path.sep).
path.resolve on the workspaceFolder is not eliminating a leading slash, prefixing with a drive letter too.  Using Uri normalizes the workspace folder.  resolve works as long as a leading slash is not in the fullPath(windows specific).
Needs testing on *nix variant. 