### PR TITLE
Fix Create integration command

### DIFF
--- a/karavan-vscode/src/extension.ts
+++ b/karavan-vscode/src/extension.ts
@@ -95,7 +95,7 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(createCrd);
 
     // Create new Integration YAML command
-    const createYaml = commands.registerCommand("karavan.create-yaml", (...args: any[]) => designer.createIntegration(false, args[0].fsPath));
+    const createYaml = commands.registerCommand("karavan.create-yaml", (...args: any[]) => designer.createIntegration(false, args[0]?.fsPath));
     context.subscriptions.push(createYaml);
 
     // Open integration in designer command


### PR DESCRIPTION
fixes #370

There was no guard check in case no argument is provided. It is the case
when creating a new file. No need for this check when there is a clause
on commands forcing to have an argument as parameter. The other creation
is for the CRD file. There is already a check using an if condition
because there is a different treatment in this case.

 (failing to build locally so far so cannot test it manually. Not added a test as the project structure is not yet ready for it)