### PR TITLE
Fixed Templates load issue in kubernetes

### DIFF
--- a/karavan-app/pom.xml
+++ b/karavan-app/pom.xml
@@ -159,6 +159,7 @@
                     <include>**/application.properties</include>
                     <include>components/**</include>
                     <include>kamelets/**</include>
+                    <include>snippets/**</include>
                     <include>META-INF/**</include>
                 </includes>
             </resource>


### PR DESCRIPTION
By adding `snippets/**` to the resource list, the template file gets loaded in Kubernetes environment.