### PR TITLE
operator: Optimize and use Kubernetes approach for GVK validation in isTektonInstalled func

### DIFF
--- a/karavan-operator/Makefile
+++ b/karavan-operator/Makefile
@@ -74,7 +74,7 @@ deploy: ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	kubectl delete -f target/kubernetes/kubernetes.yml
 
-##@Bundle
+##@ Bundle
 .PHONY: bundle
 bundle:  ## Generate bundle manifests and metadata, then validate generated files.
 ## marker


### PR DESCRIPTION
This is a bit optimized approach used in Kubernetes to validate are CRD's installed or not. The benefits are:

- Not require to get a list of all CRD's with Spec (can be very large) as it's very resource consumption and heavy operation for API server
- Validates by full GVK value, not just CRD name, which can be not formal and sometimes never changing from one version to another (for v1alpha1 -> v1beta1 - v1 CRD names will be the same)