### PR TITLE
Update Tekton Dashboard release url in docs

### DIFF
--- a/karavan-cloud/AWS.md
+++ b/karavan-cloud/AWS.md
@@ -39,7 +39,7 @@ Create public subnet.
     ```
     Install Tekton Dashboard (optional)
     ```
-    kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
+    kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
     ```
     Set `disable-affinity-assistant` equals `true`
     ```

--- a/karavan-cloud/MINIKUBE.md
+++ b/karavan-cloud/MINIKUBE.md
@@ -10,7 +10,7 @@
     ```
     Install Tekton Dashboard (optional)
     ```
-    kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
+    kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
     ```
     Set `disable-affinity-assistant` equals `true`
     ```


### PR DESCRIPTION
Tekton updated its documentation, including the url of the latest Tekton Dashboard Release. The release is not available via the old url anymore. See commit in Tekton repo: https://github.com/tektoncd/dashboard/commit/e549cc17cc146e9a1d3873e80c947e2ca8ebedf7#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5aL53