### PR TITLE
Build git url along the lines of `https://user:password@gitserver.com`

### DIFF
--- a/docs/AWS/karavan-quarkus-task-aws.yaml
+++ b/docs/AWS/karavan-quarkus-task-aws.yaml
@@ -69,7 +69,7 @@ spec:
         
         if  [[ $GIT_REPOSITORY == https* ]] ;
         then
-            replacer=https://$GIT_PASSWORD@
+            replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
             prefix=https://
             url="${GIT_REPOSITORY/$prefix/$replacer}"
             git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/docs/AWS/karavan-spring-boot-task-aws.yaml
+++ b/docs/AWS/karavan-spring-boot-task-aws.yaml
@@ -69,7 +69,7 @@ spec:
 
           if  [[ $GIT_REPOSITORY == https* ]] ;
           then
-              replacer=https://$GIT_PASSWORD@
+              replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
               prefix=https://
               url="${GIT_REPOSITORY/$prefix/$replacer}"
               git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-app/src/main/resources/pipelines/karavan-task-dev-quarkus.yaml
+++ b/karavan-web/karavan-app/src/main/resources/pipelines/karavan-task-dev-quarkus.yaml
@@ -44,7 +44,7 @@ spec:
 
         if  [[ $GIT_REPOSITORY == https* ]] ;
         then
-            replacer=https://$GIT_PASSWORD@
+            replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
             prefix=https://
             url="${GIT_REPOSITORY/$prefix/$replacer}"
             git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-app/src/main/resources/pipelines/karavan-task-dev-spring-boot.yaml
+++ b/karavan-web/karavan-app/src/main/resources/pipelines/karavan-task-dev-spring-boot.yaml
@@ -44,7 +44,7 @@ spec:
 
         if  [[ $GIT_REPOSITORY == https* ]] ;
         then
-            replacer=https://$GIT_PASSWORD@
+            replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
             prefix=https://
             url="${GIT_REPOSITORY/$prefix/$replacer}"
             git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-cli/src/main/resources/quarkus-builder-script-kubernetes.sh
+++ b/karavan-web/karavan-cli/src/main/resources/quarkus-builder-script-kubernetes.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-cli/src/main/resources/quarkus-builder-script-openshift.sh
+++ b/karavan-web/karavan-cli/src/main/resources/quarkus-builder-script-openshift.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-cli/src/main/resources/spring-boot-builder-script-kubernetes.sh
+++ b/karavan-web/karavan-cli/src/main/resources/spring-boot-builder-script-kubernetes.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-cli/src/main/resources/spring-boot-builder-script-openshift.sh
+++ b/karavan-web/karavan-cli/src/main/resources/spring-boot-builder-script-openshift.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-operator/src/main/resources/quarkus-builder-script-kubernetes.sh
+++ b/karavan-web/karavan-operator/src/main/resources/quarkus-builder-script-kubernetes.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-operator/src/main/resources/quarkus-builder-script-openshift.sh
+++ b/karavan-web/karavan-operator/src/main/resources/quarkus-builder-script-openshift.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-operator/src/main/resources/spring-boot-builder-script-kubernetes.sh
+++ b/karavan-web/karavan-operator/src/main/resources/spring-boot-builder-script-kubernetes.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}

--- a/karavan-web/karavan-operator/src/main/resources/spring-boot-builder-script-openshift.sh
+++ b/karavan-web/karavan-operator/src/main/resources/spring-boot-builder-script-openshift.sh
@@ -4,7 +4,7 @@ KAMELETS_DIR="/scripts/kamelets"
 
 if  [[ $GIT_REPOSITORY == https* ]] ;
 then
-    replacer=https://$GIT_PASSWORD@
+    replacer=https://$GIT_USERNAME:$GIT_PASSWORD@
     prefix=https://
     url="${GIT_REPOSITORY/$prefix/$replacer}"
     git clone --depth 1 --branch ${GIT_BRANCH} $url ${CHECKOUT_DIR}


### PR DESCRIPTION
I used the karavan-cli-3.21.0.jar to try out Karavan on minikube, but it failed to connect to my git repository. I guess that's because the scripts all construct a git url like `https://password@gitserver.com` instead of `https://user:password@gitserver.com`.

urlencoding can be an issue, too, if someone is using a token that contains a slash, for example. But I guess that can be handled by documentation.