### PR TITLE
Update Openshift Demo with gitea

### DIFF
--- a/docs/OPENSHIFT_DEMO.md
+++ b/docs/OPENSHIFT_DEMO.md
@@ -15,14 +15,14 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
     ```
 2. Install Tekton Operator if it is not installed yet
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/pipeline-operator.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/pipeline-operator.yaml
     ```
     
     Wait until operators are ready (Status: Succeeded)
     
 3. Install Karavan Operator
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/karavan-operator.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan-operator.yaml
     ```
     Wait until operator is ready (Status: Succeeded)
 
@@ -37,7 +37,7 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
     
 2. Create Gitea instance
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/gitea.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/gitea.yaml
     ```
 
     Wait until Gitea is ready
@@ -46,12 +46,12 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
 
 3. Create Karavan Secret
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/karavan-secret.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan-secret.yaml
     ```
 4. Create Karavan Instance
 
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/karavan.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan.yaml
     ```
 
     Wait until karavan Karavan is ready and open Karavan

--- a/docs/OPENSHIFT_DEMO.md
+++ b/docs/OPENSHIFT_DEMO.md
@@ -9,22 +9,18 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
 ### Installation
 
 #### Install Operators
-1. Install the Red Hat GPTE CatalogSource into your cluster (required for Gitea Operator)
+1. Install Gitea Operator
     ```
-    oc apply -f https://raw.githubusercontent.com/redhat-gpte-devopsautomation/gitea-operator/master/catalog_source.yaml
+    oc apply -k https://github.com/rhpds/gitea-operator/OLMDeploy
     ```
-2. Install Gitea Operator
-    ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/gitea-operator.yaml
-    ```
-3. Install Tekton Operator if it is not installed yet
+2. Install Tekton Operator if it is not installed yet
     ```
     oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/pipeline-operator.yaml
     ```
     
     Wait until operators are ready (Status: Succeeded)
     
-4. Install Karavan Operator
+3. Install Karavan Operator
     ```
     oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/karavan-cloud/openshift/karavan-operator.yaml
     ```

--- a/docs/OPENSHIFT_DEMO.md
+++ b/docs/OPENSHIFT_DEMO.md
@@ -37,7 +37,7 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
     
 2. Create Gitea instance
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/gitea.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/gitea.yaml -n karavan
     ```
 
     Wait until Gitea is ready
@@ -46,12 +46,12 @@ Karavan cloud-native integration toolkit demo on OpenShift with Gitea repository
 
 3. Create Karavan Secret
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan-secret.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan-secret.yaml -n karavan
     ```
 4. Create Karavan Instance
 
     ```
-    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan.yaml
+    oc apply -f https://raw.githubusercontent.com/apache/camel-karavan/main/docs/openshift/karavan.yaml -n karavan
     ```
 
     Wait until karavan Karavan is ready and open Karavan

--- a/docs/openshift/gitea.yaml
+++ b/docs/openshift/gitea.yaml
@@ -1,4 +1,4 @@
-apiVersion:  gitea.pfe.rhpds.com/v1
+apiVersion: pfe.rhpds.com/v1
 kind: Gitea
 metadata:
   name: gitea

--- a/docs/openshift/gitea.yaml
+++ b/docs/openshift/gitea.yaml
@@ -1,4 +1,4 @@
-apiVersion: gpte.opentlc.com/v1
+apiVersion:  gitea.pfe.rhpds.com/v1
 kind: Gitea
 metadata:
   name: gitea


### PR DESCRIPTION
Update to new version of gitea-operator. The old source is not valid anymore. In addition the urls in the documentation were wrong.