### PR TITLE
Import file validation

### DIFF
--- a/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/git/GitService.java
+++ b/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/git/GitService.java
@@ -309,11 +309,14 @@ public class GitService {
     }
 
     private PersonIdent getPersonIdent() {
+        String defaultEmailAddress = "karavan@test.org";
+
         if (securityIdentity != null && securityIdentity.getAttributes().get("userinfo") != null) {
             UserInfo userInfo = (UserInfo) securityIdentity.getAttributes().get("userinfo");
-            return new PersonIdent(securityIdentity.getPrincipal().getName(), userInfo.getEmail());
+            String email = Objects.isNull(userInfo.getEmail()) || userInfo.getEmail().isBlank() ? defaultEmailAddress : userInfo.getEmail();
+            return new PersonIdent(securityIdentity.getPrincipal().getName(), email);
         }
-        return new PersonIdent("karavan", "karavan@test.org");
+        return new PersonIdent("karavan", defaultEmailAddress);
     }
 
     public Git init(String dir, String uri, String branch) throws GitAPIException, IOException, URISyntaxException {

--- a/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/infinispan/InfinispanService.java
+++ b/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/infinispan/InfinispanService.java
@@ -17,8 +17,10 @@
 package org.apache.camel.karavan.infinispan;
 
 import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.apache.camel.karavan.infinispan.model.*;
+import org.apache.camel.karavan.validation.project.ProjectFileCreateValidator;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -62,6 +64,9 @@ public class InfinispanService implements HealthCheck {
     String infinispanUsername;
     @ConfigProperty(name = "karavan.infinispan.password")
     String infinispanPassword;
+
+    @Inject
+    ProjectFileCreateValidator projectFileCreateValidator;
 
     private RemoteCache<GroupedKey, Project> projects;
     private RemoteCache<GroupedKey, ProjectFile> files;
@@ -174,6 +179,8 @@ public class InfinispanService implements HealthCheck {
     }
 
     public void saveProjectFile(ProjectFile file) {
+        projectFileCreateValidator.validate(file).failOnError();
+
         files.put(GroupedKey.create(file.getProjectId(), DEFAULT_ENVIRONMENT, file.getName()), file);
     }
 

--- a/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/validation/project/ProjectFileCreateValidator.java
+++ b/karavan-web/karavan-app/src/main/java/org/apache/camel/karavan/validation/project/ProjectFileCreateValidator.java
@@ -1,0 +1,35 @@
+package org.apache.camel.karavan.validation.project;
+
+import java.util.List;
+
+import org.apache.camel.karavan.infinispan.InfinispanService;
+import org.apache.camel.karavan.infinispan.model.ProjectFile;
+import org.apache.camel.karavan.shared.validation.SimpleValidator;
+import org.apache.camel.karavan.shared.validation.ValidationError;
+import org.apache.camel.karavan.shared.validation.Validator;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ProjectFileCreateValidator extends Validator<ProjectFile> {
+
+    private final SimpleValidator simpleValidator;
+    private final InfinispanService infinispanService;
+
+    public ProjectFileCreateValidator(SimpleValidator simpleValidator, InfinispanService infinispanService) {
+        this.simpleValidator = simpleValidator;
+        this.infinispanService = infinispanService;
+    }
+
+
+    @Override
+    protected void validationRules(ProjectFile value, List<ValidationError> errors) {
+        simpleValidator.validate(value, errors);
+
+        boolean projectFileExists = infinispanService.getProjectFile(value.getProjectId(), value.getName()) != null;
+
+        if(projectFileExists) {
+            errors.add(new ValidationError("name", "File with given name already exists"));
+        }
+    }
+}

--- a/karavan-web/karavan-app/src/main/resources/application.properties
+++ b/karavan-web/karavan-app/src/main/resources/application.properties
@@ -145,8 +145,9 @@ quarkus.kubernetes-client.devservices.enabled=false
 
 quarkus.swagger-ui.always-include=true
 
-quarkus.quinoa.frozen-lockfile=false
+quarkus.quinoa.ci=false
 quarkus.quinoa.package-manager-install=false
 quarkus.quinoa.package-manager-install.node-version=18.12.1
 quarkus.quinoa.dev-server.port=3003
 quarkus.quinoa.dev-server.check-timeout=60000
+quarkus.quinoa.ignored-path-prefixes=/api,/public

--- a/karavan-web/karavan-app/src/main/webui/src/api/KaravanApi.tsx
+++ b/karavan-web/karavan-app/src/main/webui/src/api/KaravanApi.tsx
@@ -267,12 +267,16 @@ export class KaravanApi {
         });
     }
 
+    static async saveProjectFile(file: ProjectFile) {
+        return instance.post('/api/file', file);
+    }
+
     static async postProjectFile(file: ProjectFile, after: (res: AxiosResponse<any>) => void) {
         instance.post('/api/file', file)
             .then(res => {
                 after(res);
             }).catch(err => {
-            after(err);
+                after(err);
         });
     }
 
@@ -621,14 +625,9 @@ export class KaravanApi {
         });
     }
 
-    static async postOpenApi(file: ProjectFile, generateRest: boolean, generateRoutes: boolean, integrationName: string, after: (res: AxiosResponse<any>) => void) {
+    static async postOpenApi(file: ProjectFile, generateRest: boolean, generateRoutes: boolean, integrationName: string) {
         const uri = `/api/file/openapi/${generateRest}/${generateRoutes}/${integrationName}`;
-        instance.post(encodeURI(uri), file)
-            .then(res => {
-                after(res);
-            }).catch(err => {
-            after(err);
-        });
+        return instance.post(encodeURI(uri), file);
     }
 
     static async fetchData(type: 'container' | 'build' | 'none', podName: string, controller: AbortController) {

--- a/karavan-web/karavan-app/src/main/webui/src/api/ProjectService.ts
+++ b/karavan-web/karavan-app/src/main/webui/src/api/ProjectService.ts
@@ -245,15 +245,14 @@ export class ProjectService {
         return result.data;
     }
 
-    public static createFile(file: ProjectFile) {
-        KaravanApi.postProjectFile(file, res => {
-            if (res.status === 200) {
-                // console.log(res) //TODO show notification
-                ProjectService.refreshProjectData(file.projectId);
-            } else {
-                // console.log(res) //TODO show notification
-            }
-        })
+    public static async createFile(file: ProjectFile) {
+        const result = await KaravanApi.saveProjectFile(file);
+        return result.data;
+    }
+
+    public static async createOpenApiFile(file: ProjectFile, generateRest: boolean, generateRoutes: boolean, integrationName: string) {
+        const result = await KaravanApi.postOpenApi(file, generateRest, generateRoutes, integrationName);
+        return result.data;
     }
 
     public static deleteFile(file: ProjectFile) {

--- a/karavan-web/karavan-app/src/main/webui/src/topology/TopologyToolbar.tsx
+++ b/karavan-web/karavan-app/src/main/webui/src/topology/TopologyToolbar.tsx
@@ -34,7 +34,7 @@ export function TopologyToolbar (props: Props) {
         <ToolbarContent>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add Integration Route"} position={"bottom"}>
-                    <Button size="sm"
+                    <Button className="dev-action-button" size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddRoute()}
@@ -45,7 +45,7 @@ export function TopologyToolbar (props: Props) {
             </ToolbarItem>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add REST API"} position={"bottom"}>
-                    <Button size="sm"
+                    <Button className="dev-action-button" size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddREST()}
@@ -56,7 +56,7 @@ export function TopologyToolbar (props: Props) {
             </ToolbarItem>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add Bean"} position={"bottom"}>
-                    <Button size="sm"
+                    <Button className="dev-action-button" size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddBean()}

--- a/karavan-web/karavan-app/src/main/webui/src/topology/TopologyToolbar.tsx
+++ b/karavan-web/karavan-app/src/main/webui/src/topology/TopologyToolbar.tsx
@@ -34,7 +34,7 @@ export function TopologyToolbar (props: Props) {
         <ToolbarContent>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add Integration Route"} position={"bottom"}>
-                    <Button className="dev-action-button" size="sm"
+                    <Button size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddRoute()}
@@ -45,7 +45,7 @@ export function TopologyToolbar (props: Props) {
             </ToolbarItem>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add REST API"} position={"bottom"}>
-                    <Button className="dev-action-button" size="sm"
+                    <Button size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddREST()}
@@ -56,7 +56,7 @@ export function TopologyToolbar (props: Props) {
             </ToolbarItem>
             <ToolbarItem align={{default:"alignRight"}}>
                 <Tooltip content={"Add Bean"} position={"bottom"}>
-                    <Button className="dev-action-button" size="sm"
+                    <Button size="sm"
                             variant={"primary"}
                             icon={<PlusIcon/>}
                             onClick={e => props.onClickAddBean()}


### PR DESCRIPTION
@mgubaidullin Here's an implementation for validating file existence on project file import/upload. I've also propagated the same validation on file creation, so it's uniform and both uses the generic validator previously implemented.
There also a small fix in getPersonIdent method to use default e-mail address if it's not defined in UserInfo.
Also fixed a couple of quarkus quinoa properties, because quinoa was not working after the version upgrade.