### PR TITLE
Minor fixes on env vars and runtime for kubernetes

### DIFF
--- a/docs/install/karavan-kubernetes/deployment.yaml
+++ b/docs/install/karavan-kubernetes/deployment.yaml
@@ -23,47 +23,47 @@ spec:
           value: "3s"
         - name: "KARAVAN_DEVMODE_IMAGE"
           value: "ghcr.io/apache/camel-karavan-devmode:4.7.1"
-        - name: "karavan.git.repository"
+        - name: "KARAVAN_GIT_REPOSITORY"
           valueFrom:
             secretKeyRef:
               key: "karavan.git.repository"
               name: "karavan"
-        - name: "karavan.git.username"
+        - name: "KARAVAN_GIT_USERNAME"
           valueFrom:
             secretKeyRef:
               key: "karavan.git.username"
               name: "karavan"
-        - name: "karavan.git.password"
+        - name: "KARAVAN_GIT_PASSWORD"
           valueFrom:
             secretKeyRef:
               key: "karavan.git.password"
               name: "karavan"
-        - name: "karavan.git.branch"
+        - name: "KARAVAN_GIT_BRANCH"
           valueFrom:
             secretKeyRef:
               key: "karavan.git.branch"
               name: "karavan"
-        - name: "karavan.keycloak.url"
+        - name: "KARAVAN_KEYCLOAK_URL"
           valueFrom:
             secretKeyRef:
               key: "karavan.keycloak.url"
               name: "karavan"
-        - name: "karavan.keycloak.realm"
+        - name: "KARAVAN_KEYCLOAK_REALM"
           valueFrom:
             secretKeyRef:
               key: "karavan.keycloak.realm"
               name: "karavan"
-        - name: "karavan.keycloak.frontend.clientId"
+        - name: "KARAVAN_KEYCLOAK_FRONTEND_CLIENTID"
           valueFrom:
             secretKeyRef:
               key: "karavan.keycloak.frontend.clientId"
               name: "karavan"
-        - name: "karavan.keycloak.backend.clientId"
+        - name: "KARAVAN_KEYCLOAK_BACKEND_CLIENTID"
           valueFrom:
             secretKeyRef:
               key: "karavan.keycloak.backend.clientId"
               name: "karavan"
-        - name: "karavan.keycloak.backend.secret"
+        - name: "KARAVAN_KEYCLOAK_BACKEND_SECRET"
           valueFrom:
             secretKeyRef:
               key: "karavan.keycloak.backend.secret"

--- a/karavan-app/src/main/docker/Dockerfile
+++ b/karavan-app/src/main/docker/Dockerfile
@@ -24,7 +24,6 @@ LABEL "org.apache.camel.karavan/type"="internal"
 
 RUN mkdir /opt/app
 COPY target/*-runner.jar /opt/app/karavan.jar
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:-UseG1GC -XX:+UseZGC"
 EXPOSE 8080
 
 CMD exec "java" \

--- a/karavan-app/src/main/docker/Dockerfile
+++ b/karavan-app/src/main/docker/Dockerfile
@@ -28,13 +28,5 @@ EXPOSE 8080
 
 CMD exec "java" \
     ${JAVA_OPTS} \
-    "--add-modules" "java.se", \
-    "--add-exports" "java.base/jdk.internal.ref=ALL-UNNAMED" \
-    "--add-opens" "java.base/java.lang=ALL-UNNAMED" \
-    "--add-opens" "java.base/java.nio=ALL-UNNAMED" \
-    "--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED" \
-    "--add-opens" "java.management/sun.management=ALL-UNNAMED" \
-    "--add-opens" "jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED" \
-    "--add-opens" "jdk.management/com.sun.management.internal=ALL-UNNAMED" \
     "-jar" "/opt/app/karavan.jar"
 

--- a/karavan-app/src/main/docker/Dockerfile
+++ b/karavan-app/src/main/docker/Dockerfile
@@ -26,14 +26,16 @@ RUN mkdir /opt/app
 COPY target/*-runner.jar /opt/app/karavan.jar
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:-UseG1GC -XX:+UseZGC"
 EXPOSE 8080
-CMD ["java", \
-    "--add-modules", "java.se", \
-    "--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED", \
-    "--add-opens", "java.base/java.lang=ALL-UNNAMED", \
-    "--add-opens", "java.base/java.nio=ALL-UNNAMED", \
-    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", \
-    "--add-opens", "java.management/sun.management=ALL-UNNAMED", \
-    "--add-opens", "jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED", \
-    "--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED", \
-    "-jar", "/opt/app/karavan.jar"]
+
+CMD exec "java" \
+    ${JAVA_OPTS} \
+    "--add-modules" "java.se", \
+    "--add-exports" "java.base/jdk.internal.ref=ALL-UNNAMED" \
+    "--add-opens" "java.base/java.lang=ALL-UNNAMED" \
+    "--add-opens" "java.base/java.nio=ALL-UNNAMED" \
+    "--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED" \
+    "--add-opens" "java.management/sun.management=ALL-UNNAMED" \
+    "--add-opens" "jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED" \
+    "--add-opens" "jdk.management/com.sun.management.internal=ALL-UNNAMED" \
+    "-jar" "/opt/app/karavan.jar"
 

--- a/karavan-app/src/main/resources/configuration/docker/build.sh
+++ b/karavan-app/src/main/resources/configuration/docker/build.sh
@@ -11,7 +11,7 @@ git clone --depth 1 --branch $GIT_BRANCH $GIT_REPOSITORY $CODE_DIR
 
 cd $CODE_DIR/$PROJECT_ID
 
-jbang -Dcamel.jbang.version=$CAMEL_VERSION camel@apache/camel export --local-kamelet-dir=$KAMELETS_DIR
+jbang -Dcamel.jbang.version=$CAMEL_VERSION camel@apache/camel export --local-kamelet-dir=$KAMELETS_DIR --runtime=${CAMEL_JBANG_RUNTIME:-camel-main}
 
 mvn package jib:build \
   -Djib.allowInsecureRegistries=true \

--- a/karavan-app/src/main/resources/configuration/kubernetes/build.sh
+++ b/karavan-app/src/main/resources/configuration/kubernetes/build.sh
@@ -13,7 +13,7 @@ git clone --depth 1 --branch $GIT_BRANCH $GIT_REPOSITORY $CODE_DIR
 
 cd $CODE_DIR/$PROJECT_ID
 
-jbang -Dcamel.jbang.version=$CAMEL_VERSION camel@apache/camel export --local-kamelet-dir=$KAMELETS_DIR
+jbang -Dcamel.jbang.version=$CAMEL_VERSION camel@apache/camel export --local-kamelet-dir=$KAMELETS_DIR --runtime=${CAMEL_JBANG_RUNTIME:-camel-main}
 
 mvn package jib:build k8s:resource k8s:apply \
   -Djkube.namespace=${NAMESPACE} \


### PR DESCRIPTION
First of all: this is an awesome project!


This commits changes the following:

1) The vars on k8s deployment of the karavan-app
As all variables were lowercase, quarkus did not see them, resulting in errors (like not finding the git repo's URL)

2) Adds the JAVA_OPTS unused var to the command line used to run karavan-app
The var was been defined on the Dockerfile, but not used on the final command
With this change, It was replaced the docker 'exec form' with the 'shell form' so we can use the env var (or else we could not use it, as it has multiple values). I took caution to use the exec command to replace the shell by the java process (so it continues to receive OS signals)

3) Adds a default runtime to the build.sh script for k8s, or else when creating an integration using only the karavan-app on k8s (did not tested with vscode extension) de build was failing with 'The runtime option must be specified'

There are more stuff that I wish to contribute (for example: there is an error on git checkout when the repo's HEAD does not exist, even if we would not use it ), but let's see if those simple ones here are accepted first :)