### PR TITLE
Fix the usage of karavan.git.branch on git clone (Closes issue #1347)

### DIFF
--- a/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
+++ b/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
@@ -193,7 +193,7 @@ public class GitService {
             git = init(folder, gitConfig.getUri(), gitConfig.getBranch());
         } else {
             try {
-                git = clone(folder, gitConfig.getUri());
+                git = clone(folder, gitConfig.getUri(), gitConfig.getBranch());
                 var branch = git.branchList().call().stream().filter(ref -> ref.getName().equals("refs/heads/" + gitConfig.getBranch())).findFirst();
                 if (branch.isEmpty()) {
                     createBranch(git, gitConfig.getBranch());
@@ -332,11 +332,12 @@ public class GitService {
         }
     }
 
-    private Git clone(String dir, String uri) throws GitAPIException, URISyntaxException {
+    private Git clone(String dir, String uri, String branch) throws GitAPIException, URISyntaxException {
         CloneCommand command = Git.cloneRepository();
         command.setCloneAllBranches(false);
         command.setDirectory(Paths.get(dir).toFile());
         command.setURI(uri);
+        command.setBranch(branch);
         setCredentials(command);
         Git git = command.call();
         addRemote(git, uri);
@@ -430,7 +431,7 @@ public class GitService {
         GitConfig gitConfig = getGitConfig();
         String uuid = UUID.randomUUID().toString();
         String folder = vertx.fileSystem().createTempDirectoryBlocking(uuid);
-        try (Git git = clone(folder, gitConfig.getUri())) {
+        try (Git git = clone(folder, gitConfig.getUri(), gitConfig.getBranch())) {
             LOGGER.info("Git is ready");
         } catch (Exception e) {
             LOGGER.info("Error connecting git: " + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));

--- a/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
+++ b/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
@@ -202,7 +202,7 @@ public class GitService {
                     checkout(git, false, null, null, gitConfig.getBranch());
                 }
             } catch (RefNotFoundException | InvalidRemoteException | TransportException e) {
-                LOGGER.error("New repository");
+                LOGGER.error("New repository", e);
                 git = init(folder, gitConfig.getUri(), gitConfig.getBranch());
             } catch (Exception e) {
                 LOGGER.error("Error", e);


### PR DESCRIPTION
Two small changes on this PR:


change 1) Adds more details on log message on git init
When something went wrong on the git clone process, I was getting those logs entries:

![Screenshot from 2024-09-02 16-48-10-commit-1](https://github.com/user-attachments/assets/7d0da933-b956-404d-911d-17598c89a6b8)


And was not able to know what was going on (had to debug to check)

So just added the exception to the log message to get a clearer picture:

![image](https://github.com/user-attachments/assets/dcfcfb0a-39d8-40ce-a948-22bb5cec7045)


(note: this change would have helped the guy from https://github.com/apache/camel-karavan/issues/1347 to know the variable name was wrong, I think...)



change 2) Adds the configured branch name to git clone command, to prevent errors like these:
![Screenshot from 2024-09-02 17-04-00-commit-2](https://github.com/user-attachments/assets/82c2dde6-84ec-4a34-b1cb-a26983a7e7c6)

In the above case, my git repo had a different default branch from what was configured on the env var KARAVAN_GIT_BRANCH.

this, I presume, will close issue the https://github.com/apache/camel-karavan/issues/1347