### PR TITLE
Allow repository URI to start with ssh:// to use ports different to 22

### DIFF
--- a/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
+++ b/karavan-app/src/main/java/org/apache/camel/karavan/service/GitService.java
@@ -442,7 +442,7 @@ public class GitService {
     }
 
     private <T extends TransportCommand> T setCredentials(T command) {
-        if (privateKeyPath.isPresent() && repository.startsWith("git")) {
+        if (privateKeyPath.isPresent() && (repository.startsWith("git") || repository.startsWith("ssh://"))) {
             LOGGER.info("Set SshTransport");
             command.setTransportConfigCallback(transport -> {
                 SshTransport sshTransport = (SshTransport) transport;


### PR DESCRIPTION
SSH repo URIs can be specified in two ways for jgit. ssh://user@host:port/path and a shorter one git@host:user/repopath.

This fix enables the usage of the former one. That enables the usage of ports different to port 22.

Note: As jgit supports another protocol named "git" directly, we should probably look for "git@" at the start instead of "git", as "git://" starts with "git", but is not an ssh protocol.