### PR TITLE
Use quarkus-jgit gitea devservice

### DIFF
--- a/karavan-app/src/main/resources/application.properties
+++ b/karavan-app/src/main/resources/application.properties
@@ -104,3 +104,12 @@ quarkus.quinoa.package-manager-install.node-version=22.9.0
 quarkus.quinoa.dev-server.port=3003
 quarkus.quinoa.dev-server.check-timeout=60000
 quarkus.quinoa.ignored-path-prefixes=/ui,/public
+
+quarkus.jgit.devservices.enabled=true
+
+karavan.git.repository=${quarkus.jgit.devservices.http-url}/karavan/karavan.git
+quarkus.jgit.devservices.admin-username=karavan
+quarkus.jgit.devservices.admin-password=karavankaravan
+quarkus.jgit.devservices.oranizations=karavan
+quarkus.jgit.devservices.repositories=karavan
+


### PR DESCRIPTION
Recently, we've added gitea dev service as part of the quarkus-jgit extension. This pull request adds the required configuration so that it can be used when running the karavan app in dev mode.