### PR TITLE
Fix Docker health check response to return 'up'

### DIFF
--- a/karavan-app/src/main/java/org/apache/camel/karavan/docker/DockerService.java
+++ b/karavan-app/src/main/java/org/apache/camel/karavan/docker/DockerService.java
@@ -630,6 +630,6 @@ public class DockerService implements org.eclipse.microprofile.health.HealthChec
                 return HealthCheckResponse.named("Docker").up().build();
             }
         }
-        return HealthCheckResponse.named("Docker").down().build();
+        return HealthCheckResponse.named("Docker").up().build();
     }
 }


### PR DESCRIPTION
Fix #1579 