### PR TITLE
Deploy button should be hidden for k8s if kubernetes.yaml does not exist

### DIFF
--- a/karavan-app/package-lock.json
+++ b/karavan-app/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "karavan-app",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
**Deployment button logic improvements:**

* The Deploy button in `DeploymentButtons.tsx` is now only shown if the `files` array includes a file named `KUBERNETES_YAML`, preventing accidental deployments without the required configuration.
* Added `useFilesStore` to the imports and component state to access the list of files for this logic.
