### PR TITLE
Fix application.properties empty in UI. Fixes #1614

### DIFF
--- a/karavan-app/src/main/webui/src/ui/features/project/developer/PropertiesEditor.tsx
+++ b/karavan-app/src/main/webui/src/ui/features/project/developer/PropertiesEditor.tsx
@@ -51,6 +51,13 @@ export function PropertiesEditor() {
         }
     }, [code]);
 
+    useEffect(() => {
+        if (file && file.code !== code) {
+            setCode(file.code);
+        }
+    }, [file?.projectId, file?.name, file?.code]);
+
+
     function saveCode() {
         if (file && code && file.code !== code) {
             file.code = code;


### PR DESCRIPTION
## Description
This PR fixes the issue where `application.properties` files appeared empty in the UI despite having content loaded in the background (Issue #1614).

## Root Cause
The issue was located in the `PropertiesEditor.tsx` component. While the file content was correctly fetched from the backend and available in the global store, the component lacked a synchronization mechanism to update its local state (`code`) when the file data became available asynchronously. As a result, the editor was initialized with an undefined value and never updated.

## Changes
- **PropertiesEditor.tsx**: Added a `useEffect` hook to synchronize the local `code` state with `file.code` whenever the file is loaded or switched. This ensures the editor correctly displays the content as soon as it's available.

Fixes #1614