### PR TITLE
Configure GitHub workflow to cancel previous PR check in case of new

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   TAG: 4.18.1


### PR DESCRIPTION
commits on same PR

It will save some resources in case of new commit on a branch PR and PR checks were not finished
Apache committers can see recommendations here
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices