### PR TITLE
Fix #1638: render form validation errors with getError instead of getHelper

### DIFF
--- a/karavan-app/src/main/webui/src/ui/util/useFormUtil.tsx
+++ b/karavan-app/src/main/webui/src/ui/util/useFormUtil.tsx
@@ -232,7 +232,7 @@ export function useFormUtil(formContext: UseFormReturn<any>) {
                         <Content className='text-field-prefix' component={ContentVariants.p}>{prefix}</Content>
                     </TextInputGroupMain>
                 </TextInputGroup>
-                {getHelper((errors as any)[fieldName])}
+                {getError((errors as any)[fieldName])}
             </FormGroup>
         )
     }
@@ -262,7 +262,7 @@ export function useFormUtil(formContext: UseFormReturn<any>) {
                         </TextInputGroup>
                     )}
                 />
-                {getHelper((errors as any)[fieldName])}
+                {getError((errors as any)[fieldName])}
             </FormGroup>
         )
     }
@@ -287,7 +287,7 @@ export function useFormUtil(formContext: UseFormReturn<any>) {
                         <FormSelectOption key={index} value={option[0]} label={option[1]}/>
                     ))}
                 </FormSelect>
-                {getHelper((errors as any)[fieldName])}
+                {getError((errors as any)[fieldName])}
             </FormGroup>
         )
     }


### PR DESCRIPTION
Fixes #1638

## Problem

`useFormUtil` has two renderers for the text below a form field:

- `getHelper(text?: string)` — renders its argument directly
- `getError(error: FieldError | undefined)` — renders `error.message`

Three helpers passed a react-hook-form `FieldError` **object** to `getHelper`, so the object was rendered as a React child and React threw *"Objects are not valid as a React child (found: object with keys {ref, type, message})"*, taking down the surrounding panel via the ErrorBoundary.

Because `getHelper` is declared to take a `string`, the `as any` cast at the call sites hid the type mismatch.

## Change

Use `getError` at the three affected call sites in `useFormUtil.tsx`:

| line | helper | reachable from UI before this change |
|---|---|---|
| 235 | `getTextFieldPrefix` | no current caller |
| 265 | `getTextFieldSuffix` | **yes** — `CreateProjectModal.tsx:156` |
| 290 | `getFormSelect` | no current caller |

The `getTextFieldSuffix` case is the user-visible one. `CreateProjectModal` validates with `mode: "all"` and requires a name longer than 3 characters, so the first character typed into the **Name** field always produced an error object and crashed the dialog — making the name impossible to type. Pasting a valid name worked, since `onChange` then fired once with a value that passed validation.

The other two are latent and would fail the same way as soon as a caller adds validation.

## Verification

Reproduced on `main` by typing a single character into the Name field of the create dialog, then confirmed with this change applied that the same keystroke renders the expected `File name should be longer that 3 characters` message and the dialog behaves normally.

## Note, not addressed here

`getTextFieldSuffix` also has its invalid-state styling commented out (`// validated={...}`, line 254), so the field is not visually marked as invalid even now that the message renders. Left alone to keep this change minimal.
